### PR TITLE
doc: Avoid downloading unscoped package by updating README with @financial-times scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ In aditional, it creates a new endpoint (named \_\_health by default) which can 
 Install via npm in the root of your Serverless service:
 
 ```
-npm install serverless-plugin-healthcheck --save-dev
+npm install @financial-times/serverless-plugin-healthcheck --save-dev
 ```
 
 * Add the plugin to the `plugins` array in your Serverless `serverless.yml`:
 
 ```yml
 plugins:
-  - serverless-plugin-healthcheck
+  - '@financial-times/serverless-plugin-healthcheck'
 ```
 
 * Add a `healthcheck` property to all the events in all the functions you want to be checked.


### PR DESCRIPTION
**Steps to reproduce**

1. `mkdir newNodeProject`
1. `cd newNodeProject`
1. `npm init`
1. From README: `npm install serverless-plugin-healthcheck --save-dev`

**Expected Result**

Plugin version 0.0.8 should be added to `package.json`.  It should be [this package on npmjs](https://www.npmjs.com/package/@financial-times/serverless-plugin-healthcheck).  It's the latest available version of the package.

**Actual Result**

Plugin version 0.0.3 is added to `package.json`.  It's actually [this package on npmjs](https://www.npmjs.com/package/serverless-plugin-healthcheck), which isn't what I expected.  This **isn't** the latest available version of the package.

**What's going on**

There are two published packages on npmjs.  One is outdated.  The scoped package is the most up-to-date, is probably the correct package, and if this is the case, correctly referenced in the documentation.

<img width="863" alt="screen shot 2018-10-16 at 11 36 24 am" src="https://user-images.githubusercontent.com/3073939/47039035-ca2aa900-d137-11e8-86db-e8ca41c40a45.png">

**What this pull request does**

Updates `README.md` to include the `@financial-times` scope.  Those who wish to use this plugin will then be pointed to the most up-to-date version of the package.
